### PR TITLE
Makefile: Add install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@
 
 CROSS_COMPILE ?= aarch64-linux-gnu-
 CC ?= $(CROSS_COMPILE)gcc
+INSTALL_PROGRAM ?= install
+bindir ?= /usr/bin
 EXEC := image_update
 c_SOURCES := $(wildcard *.c)
 INCLUDES := $(wildcard *.h)
@@ -14,6 +16,9 @@ all: $(EXEC)
 
 $(EXEC): $(c_SOURCES)
 	$(CC) $< -o $@
+
+install: $(EXEC)
+	$(INSTALL_PROGRAM) -D -m 755 $(EXEC) $(DESTDIR)$(bindir)/$(EXEC)
 
 clean:
 	rm -rf $(OBJS) image_update


### PR DESCRIPTION
hi,

This adds an install target to the Makefile; this makes downstream packaging a tad easier!

Loïc Minier